### PR TITLE
Validate frequency being deallocated

### DIFF
--- a/chapter5/frequency.erl
+++ b/chapter5/frequency.erl
@@ -67,4 +67,8 @@ allocate({[Freq|Free], Allocated}, Pid) ->
 
 deallocate({Free, Allocated}, Freq) ->
   NewAllocated=lists:keydelete(Freq, 1, Allocated),
-  {[Freq|Free],  NewAllocated}.
+  case NewAllocated of
+    Allocated -> {Free,  Allocated};
+    _         -> {[Freq|Free],  NewAllocated}
+  end.
+


### PR DESCRIPTION
Don't add Freq to Free if it wasn't actually in Allocated.
Alternatively, could be stricter and fail rather than silently ignoring.

I'd submitted [a PR](https://github.com/oreillymedia/erlang_programming/pull/2) to the O'Reilly repo a while back, and was reminded of it by [your tweet today](https://twitter.com/FrancescoC/status/614344211639500800)
